### PR TITLE
Extract Codec and Client modules from Irmin_rpc

### DIFF
--- a/src/irmin-rpc-mirage/irmin_rpc_mirage.ml
+++ b/src/irmin-rpc-mirage/irmin_rpc_mirage.ml
@@ -47,9 +47,7 @@ struct
   end
 
   module Client = struct
-    type t = Irmin_rpc.t
-
-    include Irmin_rpc.Client (Store)
+    include Irmin_rpc.Client.Make (Store)
 
     let connect stack uri =
       let dns = Dns.create stack in

--- a/src/irmin-rpc-mirage/irmin_rpc_mirage.mli
+++ b/src/irmin-rpc-mirage/irmin_rpc_mirage.mli
@@ -27,10 +27,8 @@ module Make
   end
 
   module Client : sig
-    type t = Irmin_rpc.t
+    include Irmin_rpc.Client.S with module Store = Store
 
     val connect : Stack.t -> Uri.t -> t Lwt.t
-
-    include Irmin_rpc.CLIENT with module Store = Store
   end
 end

--- a/src/irmin-rpc-unix/irmin_rpc_unix.ml
+++ b/src/irmin-rpc-unix/irmin_rpc_unix.ml
@@ -25,9 +25,7 @@ module Make (Store : Irmin.S) (Remote : Irmin_rpc.REMOTE) = struct
   end
 
   module Client = struct
-    type t = Irmin_rpc.t
-
-    include Irmin_rpc.Client (Store)
+    include Irmin_rpc.Client.Make (Store)
 
     let connect uri =
       let client_vat = Capnp_rpc_unix.client_only_vat () in

--- a/src/irmin-rpc-unix/irmin_rpc_unix.mli
+++ b/src/irmin-rpc-unix/irmin_rpc_unix.mli
@@ -18,10 +18,8 @@ module Make (Store : Irmin.S) (Remote : Irmin_rpc.REMOTE) : sig
   end
 
   module Client : sig
-    type t = Irmin_rpc.t
+    include Irmin_rpc.Client.S with module Store = Store
 
     val connect : Uri.t -> t Lwt.t
-
-    include Irmin_rpc.CLIENT with module Store = Store
   end
 end

--- a/src/irmin-rpc/client.ml
+++ b/src/irmin-rpc/client.ml
@@ -1,0 +1,253 @@
+include Client_intf
+open Capnp_rpc_lwt
+open Lwt.Infix
+
+exception Error_message of string
+
+let unwrap = function Ok x -> x | Error (`Msg m) -> raise (Error_message m)
+
+module Make (Store : Irmin.S) = struct
+  module Store = Store
+  module Ir = Raw.Client.Irmin
+  module Codec = Codec.Make (Store)
+
+  type t = capability
+
+  let branch_param branch_set p branch =
+    match branch with
+    | Some br ->
+        let br = Irmin.Type.to_string Store.branch_t br in
+        branch_set p br
+    | None -> branch_set p "master"
+
+  let author_param author_set p author =
+    match author with Some author -> author_set p author | _ -> ()
+
+  let message_param message_set p message =
+    match message with Some message -> message_set p message | _ -> ()
+
+  let find t ?branch key =
+    let open Ir.Find in
+    let req, p = Capability.Request.create Params.init_pointer in
+    branch_param Params.branch_set p branch;
+    let key_s = Irmin.Type.to_string Store.key_t key in
+    Params.key_set p key_s |> ignore;
+    Capability.call_for_value_exn t method_id req >|= fun res ->
+    if Results.has_result res then
+      Some
+        ( Irmin.Type.of_string Store.contents_t (Results.result_get res)
+        |> unwrap )
+    else None
+
+  let get t ?branch key =
+    find t ?branch key >|= function
+    | Some x -> x
+    | None -> raise (Error_message "Not found")
+
+  let set t ?branch ?author ?message key value =
+    let open Ir.Set in
+    let req, p = Capability.Request.create Params.init_pointer in
+    branch_param Params.branch_set p branch;
+    author_param Params.author_set p author;
+    message_param Params.message_set p message;
+    let key_s = Irmin.Type.to_string Store.key_t key in
+    Params.key_set p key_s |> ignore;
+    Params.value_set p (Irmin.Type.to_string Store.contents_t value);
+    Capability.call_for_value_exn t method_id req >|= fun res ->
+    if Results.has_result res then
+      let commit = Results.result_get res in
+      Raw.Reader.Irmin.Commit.hash_get commit
+      |> Irmin.Type.of_string Store.Hash.t
+      |> unwrap
+    else raise (Error_message "Unable to set key")
+
+  let remove t ?branch ?author ?message key =
+    let open Ir.Remove in
+    let req, p = Capability.Request.create Params.init_pointer in
+    branch_param Params.branch_set p branch;
+    author_param Params.author_set p author;
+    message_param Params.message_set p message;
+    let key_s = Irmin.Type.to_string Store.key_t key in
+    Params.key_set p key_s |> ignore;
+    Capability.call_for_value_exn t method_id req >|= fun res ->
+    let commit = Results.result_get res in
+    Raw.Reader.Irmin.Commit.hash_get commit
+    |> Irmin.Type.of_string Store.Hash.t
+    |> unwrap
+
+  let merge t ?branch ?author ?message from_ =
+    let open Ir.Merge in
+    let req, p = Capability.Request.create Params.init_pointer in
+    branch_param Params.branch_into_set p branch;
+    let from_ = Irmin.Type.to_string Store.branch_t from_ in
+    Params.branch_from_set p from_;
+    author_param Params.author_set p author;
+    message_param Params.message_set p message;
+    Capability.call_for_value t method_id req >|= fun res ->
+    match res with
+    | Ok res ->
+        let commit = Results.result_get res in
+        Ok
+          ( Raw.Reader.Irmin.Commit.hash_get commit
+          |> Irmin.Type.of_string Store.Hash.t
+          |> unwrap )
+    | Error (`Capnp err) ->
+        let err = Fmt.to_to_string Capnp_rpc.Error.pp err in
+        Error (`Msg err)
+
+  let snapshot ?branch t =
+    let open Ir.Snapshot in
+    let req, p = Capability.Request.create Params.init_pointer in
+    branch_param Params.branch_set p branch;
+    Capability.call_for_value_exn t method_id req >|= fun res ->
+    if Results.has_result res then
+      let commit = Results.result_get res in
+      Some (Irmin.Type.of_string Store.Hash.t commit |> unwrap)
+    else None
+
+  let revert t ?branch hash =
+    let open Ir.Revert in
+    let req, p = Capability.Request.create Params.init_pointer in
+    branch_param Params.branch_set p branch;
+    Params.hash_set p (Irmin.Type.to_string Store.Hash.t hash);
+    Capability.call_for_value_exn t method_id req >|= fun res ->
+    Results.result_get res
+
+  module Tree = struct
+    let set t ?branch ?author ?message key tree =
+      let open Ir.SetTree in
+      let req, p = Capability.Request.create Params.init_pointer in
+      branch_param Params.branch_set p branch;
+      author_param Params.author_set p author;
+      message_param Params.message_set p message;
+      let key_s = Irmin.Type.to_string Store.key_t key in
+      Params.key_set p key_s |> ignore;
+      let tr = Params.tree_init p in
+      Codec.encode_tree tr key tree >>= fun () ->
+      Capability.call_for_value_exn t method_id req >|= fun res ->
+      let commit = Results.result_get res in
+      Raw.Reader.Irmin.Commit.hash_get commit
+      |> Irmin.Type.of_string Store.Hash.t
+      |> unwrap
+
+    let find t ?branch key =
+      let open Ir.FindTree in
+      let req, p = Capability.Request.create Params.init_pointer in
+      branch_param Params.branch_set p branch;
+      let key_s = Irmin.Type.to_string Store.key_t key in
+      Params.key_set p key_s |> ignore;
+      Capability.call_for_value_exn t method_id req >|= fun res ->
+      if Results.has_result res then
+        Some
+          (Results.result_get res |> Codec.decode_tree |> Store.Tree.of_concrete)
+      else None
+
+    let get t ?branch key =
+      find t ?branch key >|= function
+      | Some x -> x
+      | None -> raise (Error_message "Not found")
+  end
+
+  module Sync = struct
+    let clone t ?branch remote =
+      let open Ir.Clone in
+      let req, p = Capability.Request.create Params.init_pointer in
+      branch_param Params.branch_set p branch;
+      Params.remote_set p remote;
+      Capability.call_for_value t method_id req >|= function
+      | Ok res ->
+          let commit = Results.result_get res in
+          Ok
+            ( Raw.Reader.Irmin.Commit.hash_get commit
+            |> Irmin.Type.of_string Store.Hash.t
+            |> unwrap )
+      | Error (`Capnp err) ->
+          let s = Fmt.to_to_string Capnp_rpc.Error.pp err in
+          Error (`Msg s)
+
+    let pull t ?branch ?author ?message remote =
+      let open Ir.Pull in
+      let req, p = Capability.Request.create Params.init_pointer in
+      branch_param Params.branch_set p branch;
+      author_param Params.author_set p author;
+      message_param Params.message_set p message;
+      Params.remote_set p remote;
+      Capability.call_for_value t method_id req >|= function
+      | Ok res ->
+          let commit = Results.result_get res in
+          Ok
+            ( Raw.Reader.Irmin.Commit.hash_get commit
+            |> Irmin.Type.of_string Store.Hash.t
+            |> unwrap )
+      | Error (`Capnp err) ->
+          let s = Fmt.to_to_string Capnp_rpc.Error.pp err in
+          Error (`Msg s)
+
+    let push t ?branch remote =
+      let open Ir.Push in
+      let req, p = Capability.Request.create Params.init_pointer in
+      branch_param Params.branch_set p branch;
+      Params.remote_set p remote;
+      Capability.call_for_unit t method_id req >|= function
+      | Ok () -> Ok ()
+      | Error (`Capnp err) ->
+          let s = Fmt.to_to_string Capnp_rpc.Error.pp err in
+          Error (`Msg s)
+  end
+
+  module Commit = struct
+    let info t hash =
+      let open Ir.CommitInfo in
+      let req, p = Capability.Request.create Params.init_pointer in
+      Params.hash_set p (Irmin.Type.to_string Store.Hash.t hash);
+      Capability.call_for_value_exn t method_id req >|= fun res ->
+      if Results.has_result res then
+        let info = Results.result_get res in
+        let module Info = Raw.Reader.Irmin.Info in
+        let author = Info.author_get info in
+        let date = Info.date_get info in
+        let message = Info.message_get info in
+        Some (Irmin.Info.v ~date ~author message)
+      else None
+
+    let history t hash =
+      let open Ir.CommitHistory in
+      let req, p = Capability.Request.create Params.init_pointer in
+      Params.hash_set p (Irmin.Type.to_string Store.Hash.t hash);
+      Capability.call_for_value_exn t method_id req >>= fun res ->
+      let l = Results.result_get_list res in
+      Lwt_list.filter_map_s
+        (fun x ->
+          match Irmin.Type.of_string Store.Hash.t x with
+          | Ok b -> Lwt.return_some b
+          | Error _ -> Lwt.return_none)
+        l
+  end
+
+  module Branch = struct
+    let remove t branch =
+      let open Ir.RemoveBranch in
+      let req, p = Capability.Request.create Params.init_pointer in
+      branch_param Params.branch_set p (Some branch);
+      Capability.call_for_unit_exn t method_id req
+
+    let create t name hash =
+      let open Ir.CreateBranch in
+      let req, p = Capability.Request.create Params.init_pointer in
+      branch_param Params.branch_set p (Some name);
+      Params.hash_set p (Irmin.Type.to_string Store.Hash.t hash);
+      Capability.call_for_unit_exn t method_id req
+
+    let list t =
+      let open Ir.Branches in
+      let req, _ = Capability.Request.create Params.init_pointer in
+      Capability.call_for_value_exn t method_id req >>= fun res ->
+      let l = Results.result_get_list res in
+      Lwt_list.filter_map_s
+        (fun x ->
+          match Irmin.Type.of_string Store.branch_t x with
+          | Ok b -> Lwt.return_some b
+          | Error _ -> Lwt.return_none)
+        l
+  end
+end

--- a/src/irmin-rpc/client.mli
+++ b/src/irmin-rpc/client.mli
@@ -1,0 +1,1 @@
+include Client_intf.Client

--- a/src/irmin-rpc/client_intf.ml
+++ b/src/irmin-rpc/client_intf.ml
@@ -1,0 +1,98 @@
+type capability = Raw.Client.Irmin.t Capnp_rpc_lwt.Capability.t
+
+module type S = sig
+  module Store : Irmin.S
+
+  type t = capability
+
+  val get : t -> ?branch:Store.branch -> Store.key -> Store.contents Lwt.t
+
+  val find :
+    t -> ?branch:Store.branch -> Store.key -> Store.contents option Lwt.t
+
+  val set :
+    t ->
+    ?branch:Store.branch ->
+    ?author:string ->
+    ?message:string ->
+    Store.key ->
+    Store.contents ->
+    Store.Hash.t Lwt.t
+
+  val remove :
+    t ->
+    ?branch:Store.branch ->
+    ?author:string ->
+    ?message:string ->
+    Store.key ->
+    Store.Hash.t Lwt.t
+
+  val merge :
+    t ->
+    ?branch:Store.branch ->
+    ?author:string ->
+    ?message:string ->
+    Store.branch ->
+    (Store.Hash.t, [ `Msg of string ]) result Lwt.t
+
+  val snapshot : ?branch:Store.branch -> t -> Store.Hash.t option Lwt.t
+
+  val revert : t -> ?branch:Store.branch -> Store.Hash.t -> bool Lwt.t
+
+  module Tree : sig
+    val set :
+      t ->
+      ?branch:Store.branch ->
+      ?author:string ->
+      ?message:string ->
+      Store.key ->
+      Store.tree ->
+      Store.Hash.t Lwt.t
+
+    val find : t -> ?branch:Store.branch -> Store.key -> Store.tree option Lwt.t
+
+    val get : t -> ?branch:Store.branch -> Store.key -> Store.tree Lwt.t
+  end
+
+  module Sync : sig
+    val clone :
+      t ->
+      ?branch:Store.branch ->
+      string ->
+      (Store.Hash.t, [ `Msg of string ]) result Lwt.t
+
+    val pull :
+      t ->
+      ?branch:Store.branch ->
+      ?author:string ->
+      ?message:string ->
+      string ->
+      (Store.Hash.t, [ `Msg of string ]) result Lwt.t
+
+    val push :
+      t ->
+      ?branch:Store.branch ->
+      string ->
+      (unit, [ `Msg of string ]) result Lwt.t
+  end
+
+  module Commit : sig
+    val info : t -> Store.Hash.t -> Irmin.Info.t option Lwt.t
+
+    val history : t -> Store.Hash.t -> Store.Hash.t list Lwt.t
+  end
+
+  module Branch : sig
+    val list : t -> Store.branch list Lwt.t
+
+    val remove : t -> Store.branch -> unit Lwt.t
+
+    val create : t -> Store.branch -> Store.Hash.t -> unit Lwt.t
+  end
+end
+
+module type Client = sig
+  module type S = S
+
+  module Make (Store : Irmin.S) : S with module Store = Store
+end

--- a/src/irmin-rpc/codec.ml
+++ b/src/irmin-rpc/codec.ml
@@ -1,0 +1,72 @@
+include Codec_intf
+open Lwt.Infix
+
+exception Error_message of string
+
+let unwrap = function Ok x -> x | Error (`Msg m) -> raise (Error_message m)
+
+module Make (Store : Irmin.S) = struct
+  let rec encode_tree tr key (tree : Store.tree) : unit Lwt.t =
+    let module Tree = Raw.Builder.Irmin.Tree in
+    let module Node = Raw.Builder.Irmin.Node in
+    let ks = Irmin.Type.to_string Store.key_t key in
+    ignore @@ Tree.key_set tr ks;
+    Store.Tree.to_concrete tree >>= function
+    | `Contents (contents, _) ->
+        let _ =
+          Tree.contents_set tr (Irmin.Type.to_string Store.contents_t contents)
+        in
+        Lwt.return_unit
+    | `Tree l ->
+        Lwt_list.map_p
+          (fun (step, tree) ->
+            let node = Node.init_root () in
+            let step_s = Irmin.Type.to_string Store.step_t step in
+            Node.step_set node step_s;
+            let tt = Node.tree_init node in
+            let tree = Store.Tree.of_concrete tree in
+            encode_tree tt (Store.Key.rcons key step) tree >|= fun () -> node)
+          l
+        >>= fun l ->
+        let _ = Tree.node_set_list tr l in
+        Lwt.return_unit
+
+  let rec decode_tree tree : Store.Tree.concrete =
+    let module Tree = Raw.Reader.Irmin.Tree in
+    let module Node = Raw.Reader.Irmin.Node in
+    match Tree.get tree with
+    | Node l ->
+        let l = Capnp.Array.to_list l in
+        `Tree
+          (List.map
+             (fun node ->
+               let step =
+                 Node.step_get node
+                 |> Irmin.Type.of_string Store.step_t
+                 |> unwrap
+               in
+               let tree = Node.tree_get node |> decode_tree in
+               (step, tree))
+             l)
+    | Contents c ->
+        let c = Irmin.Type.of_string Store.contents_t c |> unwrap in
+        `Contents (c, Store.Metadata.default)
+    | Undefined _ -> `Tree []
+
+  let encode_commit_info cm info =
+    let module Info = Raw.Builder.Irmin.Info in
+    let i = Store.Commit.info cm in
+    Info.author_set info (Irmin.Info.author i);
+    Info.message_set info (Irmin.Info.message i);
+    Info.date_set info (Irmin.Info.date i)
+
+  let encode_commit commit cm =
+    let module Commit = Raw.Builder.Irmin.Commit in
+    let module Info = Raw.Builder.Irmin.Info in
+    let info = Commit.info_init commit in
+    let hash = Irmin.Type.to_string Store.Hash.t (Store.Commit.hash cm) in
+    Commit.hash_set commit hash;
+    let tr = Commit.tree_init commit in
+    let tree = Store.Commit.tree cm in
+    encode_tree tr Store.Key.empty tree >|= fun () -> encode_commit_info cm info
+end

--- a/src/irmin-rpc/codec.mli
+++ b/src/irmin-rpc/codec.mli
@@ -1,0 +1,2 @@
+include Codec_intf.Codec
+(** @inline *)

--- a/src/irmin-rpc/codec_intf.ml
+++ b/src/irmin-rpc/codec_intf.ml
@@ -1,0 +1,24 @@
+open Raw
+
+type tree_struct = Builder.Irmin.Tree.struct_t
+
+type info_struct = Builder.Irmin.Info.struct_t
+
+type commit_struct = Builder.Irmin.Commit.struct_t
+
+module type MAKER = functor (Store : Irmin.S) -> sig
+  val encode_tree :
+    tree_struct builder_t -> Store.key -> Store.tree -> unit Lwt.t
+
+  val decode_tree : tree_struct reader_t -> Store.Tree.concrete
+
+  val encode_commit_info : Store.commit -> info_struct builder_t -> unit
+
+  val encode_commit : commit_struct builder_t -> Store.commit -> unit Lwt.t
+end
+
+module type Codec = sig
+  module type MAKER = MAKER
+
+  module Make : MAKER
+end

--- a/src/irmin-rpc/irmin_rpc.mli
+++ b/src/irmin-rpc/irmin_rpc.mli
@@ -1,1 +1,2 @@
 include Irmin_rpc_intf.Irmin_rpc
+(** @inline *)

--- a/src/irmin-rpc/irmin_rpc_intf.ml
+++ b/src/irmin-rpc/irmin_rpc_intf.ml
@@ -1,93 +1,4 @@
-type t = [ `Irmin_b2b5cb4fd15c7d5a ] Capnp_rpc_lwt.Capability.t
-
-module type CLIENT = sig
-  module Store : Irmin.S
-
-  val get : t -> ?branch:Store.branch -> Store.key -> Store.contents Lwt.t
-
-  val find :
-    t -> ?branch:Store.branch -> Store.key -> Store.contents option Lwt.t
-
-  val set :
-    t ->
-    ?branch:Store.branch ->
-    ?author:string ->
-    ?message:string ->
-    Store.key ->
-    Store.contents ->
-    Store.Hash.t Lwt.t
-
-  val remove :
-    t ->
-    ?branch:Store.branch ->
-    ?author:string ->
-    ?message:string ->
-    Store.key ->
-    Store.Hash.t Lwt.t
-
-  val merge :
-    t ->
-    ?branch:Store.branch ->
-    ?author:string ->
-    ?message:string ->
-    Store.branch ->
-    (Store.Hash.t, [ `Msg of string ]) result Lwt.t
-
-  val snapshot : ?branch:Store.branch -> t -> Store.Hash.t option Lwt.t
-
-  val revert : t -> ?branch:Store.branch -> Store.Hash.t -> bool Lwt.t
-
-  module Tree : sig
-    val set :
-      t ->
-      ?branch:Store.branch ->
-      ?author:string ->
-      ?message:string ->
-      Store.key ->
-      Store.tree ->
-      Store.Hash.t Lwt.t
-
-    val find : t -> ?branch:Store.branch -> Store.key -> Store.tree option Lwt.t
-
-    val get : t -> ?branch:Store.branch -> Store.key -> Store.tree Lwt.t
-  end
-
-  module Sync : sig
-    val clone :
-      t ->
-      ?branch:Store.branch ->
-      string ->
-      (Store.Hash.t, [ `Msg of string ]) result Lwt.t
-
-    val pull :
-      t ->
-      ?branch:Store.branch ->
-      ?author:string ->
-      ?message:string ->
-      string ->
-      (Store.Hash.t, [ `Msg of string ]) result Lwt.t
-
-    val push :
-      t ->
-      ?branch:Store.branch ->
-      string ->
-      (unit, [ `Msg of string ]) result Lwt.t
-  end
-
-  module Commit : sig
-    val info : t -> Store.Hash.t -> Irmin.Info.t option Lwt.t
-
-    val history : t -> Store.Hash.t -> Store.Hash.t list Lwt.t
-  end
-
-  module Branch : sig
-    val list : t -> Store.branch list Lwt.t
-
-    val remove : t -> Store.branch -> unit Lwt.t
-
-    val create : t -> Store.branch -> Store.Hash.t -> unit Lwt.t
-  end
-end
+type t = Raw.Client.Irmin.t Capnp_rpc_lwt.Capability.t
 
 module type REMOTE = sig
   val remote : ?headers:Cohttp.Header.t -> string -> Irmin.remote
@@ -110,10 +21,6 @@ module type MAKER = functor (Store : Irmin.S) (_ : INFO) (_ : REMOTE) ->
 module type Irmin_rpc = sig
   type nonrec t = t
 
-  exception Error_message of string
-
-  module type CLIENT = CLIENT
-
   module type REMOTE = REMOTE
 
   module type INFO = INFO
@@ -124,5 +31,5 @@ module type Irmin_rpc = sig
 
   module Make : MAKER
 
-  module Client (Store : Irmin.S) : CLIENT with module Store = Store
+  module Client = Client
 end

--- a/src/irmin-rpc/raw.ml
+++ b/src/irmin-rpc/raw.ml
@@ -1,0 +1,1 @@
+include Irmin_api.MakeRPC (Capnp_rpc_lwt)


### PR DESCRIPTION
This also brings two code changes:

- If two non-equal stores are passed to `Client.Make`, the resulting
  store type is incompatible. As far as I can tell, the previous situation
  of them being compatible with each other was a mistake: client stores
  should inherit the type constraints of their remote equivalents.

- The `Error_message` exception is no longer exposed. It's use is not
  documented anywhere, and I think we should phase it out in favour of
  `result` types or several, distinct exception types with more
  informative names.