### PR TITLE
Require specifying values for author and message

### DIFF
--- a/examples/client.ml
+++ b/examples/client.ml
@@ -12,9 +12,11 @@ module Rpc =
 let uri =
   "capnp://sha-256:HUOdhEKv0Knk5USkfaFiXCC_l_s3dYjoayyrmu_olh4@127.0.0.1:9999/yxEIPPXH-w8pTd_ULcm4AmUsZwA5QrSfSZj_z_Vzulw"
 
+let author, message = ("rpc-client-author", "rpc-client-message")
+
 let main =
   Rpc.Client.connect (Uri.of_string uri) >>= fun client ->
-  Rpc.Client.set client [ "abc" ] "123" >>= fun _ ->
+  Rpc.Client.set client ~author ~message [ "abc" ] "123" >>= fun _ ->
   Rpc.Client.get client [ "abc" ] >|= fun res ->
   assert (res = "123");
   print_endline res

--- a/src/irmin-rpc/client.ml
+++ b/src/irmin-rpc/client.ml
@@ -20,12 +20,6 @@ module Make (Store : Irmin.S) = struct
         branch_set p br
     | None -> branch_set p "master"
 
-  let author_param author_set p author =
-    match author with Some author -> author_set p author | _ -> ()
-
-  let message_param message_set p message =
-    match message with Some message -> message_set p message | _ -> ()
-
   let find t ?branch key =
     let open Ir.Find in
     let req, p = Capability.Request.create Params.init_pointer in
@@ -44,12 +38,12 @@ module Make (Store : Irmin.S) = struct
     | Some x -> x
     | None -> raise (Error_message "Not found")
 
-  let set t ?branch ?author ?message key value =
+  let set t ?branch ~author ~message key value =
     let open Ir.Set in
     let req, p = Capability.Request.create Params.init_pointer in
     branch_param Params.branch_set p branch;
-    author_param Params.author_set p author;
-    message_param Params.message_set p message;
+    Params.author_set p author;
+    Params.message_set p message;
     let key_s = Irmin.Type.to_string Store.key_t key in
     Params.key_set p key_s |> ignore;
     Params.value_set p (Irmin.Type.to_string Store.contents_t value);
@@ -61,12 +55,12 @@ module Make (Store : Irmin.S) = struct
       |> unwrap
     else raise (Error_message "Unable to set key")
 
-  let remove t ?branch ?author ?message key =
+  let remove t ?branch ~author ~message key =
     let open Ir.Remove in
     let req, p = Capability.Request.create Params.init_pointer in
     branch_param Params.branch_set p branch;
-    author_param Params.author_set p author;
-    message_param Params.message_set p message;
+    Params.author_set p author;
+    Params.message_set p message;
     let key_s = Irmin.Type.to_string Store.key_t key in
     Params.key_set p key_s |> ignore;
     Capability.call_for_value_exn t method_id req >|= fun res ->
@@ -75,14 +69,14 @@ module Make (Store : Irmin.S) = struct
     |> Irmin.Type.of_string Store.Hash.t
     |> unwrap
 
-  let merge t ?branch ?author ?message from_ =
+  let merge t ?branch ~author ~message from_ =
     let open Ir.Merge in
     let req, p = Capability.Request.create Params.init_pointer in
     branch_param Params.branch_into_set p branch;
     let from_ = Irmin.Type.to_string Store.branch_t from_ in
     Params.branch_from_set p from_;
-    author_param Params.author_set p author;
-    message_param Params.message_set p message;
+    Params.author_set p author;
+    Params.message_set p message;
     Capability.call_for_value t method_id req >|= fun res ->
     match res with
     | Ok res ->
@@ -114,12 +108,12 @@ module Make (Store : Irmin.S) = struct
     Results.result_get res
 
   module Tree = struct
-    let set t ?branch ?author ?message key tree =
+    let set t ?branch ~author ~message key tree =
       let open Ir.SetTree in
       let req, p = Capability.Request.create Params.init_pointer in
       branch_param Params.branch_set p branch;
-      author_param Params.author_set p author;
-      message_param Params.message_set p message;
+      Params.author_set p author;
+      Params.message_set p message;
       let key_s = Irmin.Type.to_string Store.key_t key in
       Params.key_set p key_s |> ignore;
       let tr = Params.tree_init p in
@@ -165,12 +159,12 @@ module Make (Store : Irmin.S) = struct
           let s = Fmt.to_to_string Capnp_rpc.Error.pp err in
           Error (`Msg s)
 
-    let pull t ?branch ?author ?message remote =
+    let pull t ?branch ~author ~message remote =
       let open Ir.Pull in
       let req, p = Capability.Request.create Params.init_pointer in
       branch_param Params.branch_set p branch;
-      author_param Params.author_set p author;
-      message_param Params.message_set p message;
+      Params.author_set p author;
+      Params.message_set p message;
       Params.remote_set p remote;
       Capability.call_for_value t method_id req >|= function
       | Ok res ->

--- a/src/irmin-rpc/client_intf.ml
+++ b/src/irmin-rpc/client_intf.ml
@@ -13,8 +13,8 @@ module type S = sig
   val set :
     t ->
     ?branch:Store.branch ->
-    ?author:string ->
-    ?message:string ->
+    author:string ->
+    message:string ->
     Store.key ->
     Store.contents ->
     Store.Hash.t Lwt.t
@@ -22,16 +22,16 @@ module type S = sig
   val remove :
     t ->
     ?branch:Store.branch ->
-    ?author:string ->
-    ?message:string ->
+    author:string ->
+    message:string ->
     Store.key ->
     Store.Hash.t Lwt.t
 
   val merge :
     t ->
     ?branch:Store.branch ->
-    ?author:string ->
-    ?message:string ->
+    author:string ->
+    message:string ->
     Store.branch ->
     (Store.Hash.t, [ `Msg of string ]) result Lwt.t
 
@@ -43,8 +43,8 @@ module type S = sig
     val set :
       t ->
       ?branch:Store.branch ->
-      ?author:string ->
-      ?message:string ->
+      author:string ->
+      message:string ->
       Store.key ->
       Store.tree ->
       Store.Hash.t Lwt.t
@@ -64,10 +64,13 @@ module type S = sig
     val pull :
       t ->
       ?branch:Store.branch ->
-      ?author:string ->
-      ?message:string ->
+      author:string ->
+      message:string ->
       string ->
       (Store.Hash.t, [ `Msg of string ]) result Lwt.t
+    (** [pull t ~branch ~author ~message remote] pulls from the given remote
+        into the specified branch. A local merge commit is constructed using the
+        [(author, message)] metadata. *)
 
     val push :
       t ->

--- a/src/irmin-rpc/irmin_rpc.ml
+++ b/src/irmin-rpc/irmin_rpc.ml
@@ -47,18 +47,11 @@ module Make (Store : Irmin.S) (Info : INFO) (Remote : REMOTE) = struct
              Params.branch_get req
              |> Irmin.Type.of_string Store.branch_t
              |> unwrap
-           in
-           let key =
+           and key =
              Params.key_get req |> Irmin.Type.of_string Store.key_t |> unwrap
-           in
-           let value = Params.value_get req in
-           let message =
-             if Params.has_message req then Params.message_get req else "set"
-           in
-           let author =
-             if Params.has_author req then Params.author_get req
-             else "irmin-rpc"
-           in
+           and value = Params.value_get req
+           and message = Params.message_get req
+           and author = Params.author_get req in
            release_params ();
            Service.return_lwt (fun () ->
                let resp, results =
@@ -90,17 +83,10 @@ module Make (Store : Irmin.S) (Info : INFO) (Remote : REMOTE) = struct
              Params.branch_get req
              |> Irmin.Type.of_string Store.branch_t
              |> unwrap
-           in
-           let key =
+           and key =
              Params.key_get req |> Irmin.Type.of_string Store.key_t |> unwrap
-           in
-           let message =
-             if Params.has_message req then Params.message_get req else "remove"
-           in
-           let author =
-             if Params.has_author req then Params.author_get req
-             else "irmin-rpc"
-           in
+           and message = Params.message_get req
+           and author = Params.author_get req in
            release_params ();
            Service.return_lwt (fun () ->
                let resp, results =
@@ -146,19 +132,11 @@ module Make (Store : Irmin.S) (Info : INFO) (Remote : REMOTE) = struct
              Params.branch_get req
              |> Irmin.Type.of_string Store.branch_t
              |> unwrap
-           in
-           let key =
+           and key =
              Params.key_get req |> Irmin.Type.of_string Store.key_t |> unwrap
-           in
-           let tree = Params.tree_get req in
-           let message =
-             if Params.has_message req then Params.message_get req
-             else "set_tree"
-           in
-           let author =
-             if Params.has_author req then Params.author_get req
-             else "irmin-rpc"
-           in
+           and tree = Params.tree_get req
+           and message = Params.message_get req
+           and author = Params.author_get req in
            release_params ();
            Service.return_lwt (fun () ->
                let resp, results =
@@ -199,8 +177,8 @@ module Make (Store : Irmin.S) (Info : INFO) (Remote : REMOTE) = struct
 
          method push_impl req release_params =
            let open Ir.Push in
-           let remote = Params.remote_get req |> Remote.remote in
-           let branch =
+           let remote = Params.remote_get req |> Remote.remote
+           and branch =
              Params.branch_get req
              |> Irmin.Type.of_string Store.branch_t
              |> unwrap
@@ -222,29 +200,15 @@ module Make (Store : Irmin.S) (Info : INFO) (Remote : REMOTE) = struct
 
          method pull_impl req release_params =
            let open Ir.Pull in
-           let remote = Params.remote_get req |> Remote.remote in
-           let branch =
+           let remote = Params.remote_get req |> Remote.remote
+           and branch =
              Params.branch_get req
              |> Irmin.Type.of_string Store.branch_t
              |> unwrap
-           in
-           let message =
-             if Params.has_message req then Some (Params.message_get req)
-             else None
-           in
-           let author =
-             if Params.has_author req then Some (Params.author_get req)
-             else None
-           in
+           and message = Params.message_get req
+           and author = Params.author_get req in
            release_params ();
-           let info =
-             match (message, author) with
-             | None, None -> `Set
-             | Some message, None -> `Merge (Info.info "%s" message)
-             | None, Some author -> `Merge (Info.info ~author "merge")
-             | Some message, Some author ->
-                 `Merge (Info.info ~author "%s" message)
-           in
+           let info = `Merge (Info.info ~author "%s" message) in
            Service.return_lwt (fun () ->
                let resp, results =
                  Service.Response.create Results.init_pointer
@@ -271,19 +235,12 @@ module Make (Store : Irmin.S) (Info : INFO) (Remote : REMOTE) = struct
              Params.branch_from_get req
              |> Irmin.Type.of_string Store.branch_t
              |> unwrap
-           in
-           let into_ =
+           and into_ =
              Params.branch_into_get req
              |> Irmin.Type.of_string Store.branch_t
              |> unwrap
-           in
-           let message =
-             if Params.has_message req then Params.message_get req else "merge"
-           in
-           let author =
-             if Params.has_author req then Params.author_get req
-             else "irmin-rpc"
-           in
+           and message = Params.message_get req
+           and author = Params.author_get req in
            release_params ();
            let info = Info.info ~author "%s" message in
            Service.return_lwt (fun () ->


### PR DESCRIPTION
This is a step towards unifying the Client API with standard Irmin
stores. There is no performance penanty here, since Cap'n Proto has no
notion of 'optional' fields: previously we were just serialising blank
fields.